### PR TITLE
Fix telemetry by using prod image instead of dev build

### DIFF
--- a/docs/quickstart-guide/quick-install.md
+++ b/docs/quickstart-guide/quick-install.md
@@ -19,7 +19,7 @@ For more information, see the [Prerequisites](qs-prerequisites.md) section.
 2. To install Percona Everest, run the following command:
 
     ```{.bash data-prompt="$"}
-    $ curl -sfL "https://raw.githubusercontent.com/percona/percona-everest-cli/v0.4.0/install.sh" | bash
+    $ curl -sfL "https://raw.githubusercontent.com/percona/percona-everest-cli/v0.4.0/install.sh" | sed 's/release-/v/' | bash
     ```
 
     !!! note
@@ -27,7 +27,7 @@ For more information, see the [Prerequisites](qs-prerequisites.md) section.
         Everest will search for the kubeconfig file in the `~/.kube/config` path. If your file is located elsewhere, add the `KUBECONFIG` environment variable when running the `install.sh` script. 
     
     ```{.bash data-prompt="$"}
-    $ curl -sfL "https://raw.githubusercontent.com/percona/percona-everest-cli/v0.4.0/install.sh" | KUBECONFIG=<path/to/config/file> bash
+    $ curl -sfL "https://raw.githubusercontent.com/percona/percona-everest-cli/v0.4.0/install.sh" | sed 's/release-/v/' | KUBECONFIG=<path/to/config/file> bash
     ```
 
     ??? example "Expected output"


### PR DESCRIPTION
The v0.4.0 install.sh script has a bug that uses the dev build instead of the production image.
As quick workaround we'll fix it through the documentation.