### PR TITLE
Update and rename gke.md to kubectl

### DIFF
--- a/docs/quickstart-guide/kubectl
+++ b/docs/quickstart-guide/kubectl
@@ -61,7 +61,7 @@ shown on the above image. You will see the connect statement which configures
 the command-line access. After you have edited the statement, you may run the
 command in your local shell:
 
-```sh
+``` {.bash data-prompt="$" }
 $ gcloud container clusters get-credentials my-cluster-name --zone us-central1-a --project <project name>
 ```
 
@@ -70,7 +70,7 @@ to control access to the cluster. The following command will give you the
 ability to create Roles and RoleBindings:
 
 ```sh
-$ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value core/account)
+kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value core/account)
 ```
 
 ??? example "Expected output"
@@ -83,7 +83,7 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
 
 You can clean up the cluster with the `gcloud` command as follows:
 
-```sh
+```{.bash data-prompt="$" }
 $ gcloud container clusters delete <cluster name>
 ```
 


### PR DESCRIPTION
I am updating the format for gcloud commands. After copying the commands, the symbols of "$"  are also copied, which adds an extra step before executing the command to remove the dollar symbols.