### PR TITLE
EVEREST-1291 Script to check duplicated storages

### DIFF
--- a/tools/bin/check-duplicated-storages.sh
+++ b/tools/bin/check-duplicated-storages.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+backup_storage_output=$(kubectl get backupstorage -n everest-system)
+backup_storage_names=($(echo "$backup_storage_output" | awk 'NR>1 {print $1}'))
+
+get_value() {
+  local map="$1"
+  local key="$2"
+  local value=$(echo "$map"| grep "$key" | cut -d"=" -f2)
+  echo $value
+}
+
+echo "Backup storages which share the same bucket, region, endpointURL:"
+found=0
+buckets=""
+
+for name in "${backup_storage_names[@]}"; do
+  storage=$(kubectl get backupstorage "$name" -n everest-system -o json)
+
+  bucket=$(echo "$storage" | jq -r '.spec.bucket')
+  endpointURL=$(echo "$storage" | jq -r '.spec.endpointURL')
+  region=$(echo "$storage" | jq -r '.spec.region')
+
+  key="$bucket$endpointURL$region"
+  storage_name=$(echo "$storage" | jq -r '.metadata.name')
+  existing_value=$(get_value "$buckets" "$key")
+
+  if [[ ${#existing_value} -gt 0  ]]; then
+    found=1
+    echo "- $existing_value and $storage_name"
+  else
+    buckets+="$key=$storage_name\n"
+  fi
+done
+
+if [[ ${found} -eq 0  ]]; then
+  echo "not found"
+fi

--- a/tools/bin/check-duplicated-storages.sh
+++ b/tools/bin/check-duplicated-storages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 backup_storage_names=($(kubectl get backupstorage -n everest-system --no-headers -o=jsonpath='{.items[*].metadata.name}'))
 

--- a/tools/bin/check-duplicated-storages.sh
+++ b/tools/bin/check-duplicated-storages.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 backup_storage_names=($(kubectl get backupstorage -n everest-system --no-headers -o=jsonpath='{.items[*].metadata.name}'))
 
 if ! command -v kubectl &> /dev/null; then


### PR DESCRIPTION
[EVEREST-1291](https://perconadev.atlassian.net/browse/EVEREST-1291) 

Everest 1.1.0 will restrict creation of backup storage which use the same bucket, region and url. 
This script finds and prints the names of the storages which use the same bucket, region and url. 

Suggesting that the script should work in all modern environments.
The challenge was that Mac uses bash 3.2 by default, it's an old version from 2007, it is so bc of [the different license](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba). Associative arrays, which would be really handy for this script, appeared only in bash 4, so the script uses some tricks to mimic associative arrays.

Output examples:
Two pairs of storages:
```
Backup storages which share the same bucket, region, endpointURL:
- my-storage and my-storage-2
- my-storage-3 and my-storage-4
```

Three storages:
```
Backup storages which share the same bucket, region, endpointURL:
- my-storage and my-storage-2
- my-storage and my-storage-3
```

No duplicates:
```
Backup storages which share the same bucket, region, endpointURL:
not found
```