### PR TITLE
install_or_uninstall_everest_using _the same_tool

### DIFF
--- a/docs/install/installEverest.md
+++ b/docs/install/installEverest.md
@@ -7,6 +7,9 @@
 
 ## Before you start
 
+!!! info "Important:
+    If you installed Percona Everest using `everestctl`, make sure to uninstall it exclusively through `everestctl` for a seamless removal.
+
 Before running the commands in the **Installation** section, note that Everest will search for the kubeconfig file in the `~/.kube/config` path. If your file is located elsewhere, use the export command below to set the `KUBECONFIG` environment variable: 
     
 ```sh

--- a/docs/install/installEverest.md
+++ b/docs/install/installEverest.md
@@ -7,7 +7,7 @@
 
 ## Before you start
 
-!!! info "Important:
+!!! info "Important"
     If you installed Percona Everest using `everestctl`, make sure to uninstall it exclusively through `everestctl` for a seamless removal.
 
 Before running the commands in the **Installation** section, note that Everest will search for the kubeconfig file in the `~/.kube/config` path. If your file is located elsewhere, use the export command below to set the `KUBECONFIG` environment variable: 

--- a/docs/install/install_everest_helm_charts.md
+++ b/docs/install/install_everest_helm_charts.md
@@ -9,6 +9,9 @@ This section explains how to install Percona Everest using [Helm](https://helm.s
 
 Percona Helm charts can be found in [percona/percona-helm-charts]( https://github.com/percona/percona-helm-charts/tree/main/charts/everest) repository in Github.
 
+!!! info "Important"
+    If you installed Percona Everest using Helm, make sure to uninstall it exclusively through Helm for a seamless removal.
+
 ## Install Percona Everest and deploy database namespaces
 
 Here are the steps to install Percona Everest and deploy additional database namespaces:

--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -80,6 +80,7 @@ To install Percona Everest using Helm follow these steps:
     !!! note
         - If `dbNamespace.namespaceOverride` is set, the specified namespace will be provisioned instead of the default `everest` namespace.
         - If `dbNamespace.enabled=false` is set, no namespaces will be provisioned. You can provision namespaces later with the `everestctl namespaces add <NAMESPACE>` command.
+        - If you installed Percona Everest using `helm` and need to uninstall it, make sure to uninstall it exclusively through `helm` for seamless removal.
 
 ## Post-installation steps
 
@@ -150,8 +151,6 @@ Once you have successfully installed Percona Everest, proceed with the following
 
         Percona Everest will be available at [http://127.0.0.1:8080](http://127.0.0.1:8080). This method is mostly useful for testing purposes. 
 
-!!! info "important"
-    If you installed Percona Everest using `helm`, make sure to uninstall it exclusively through `helm` for a seamless removal.
 
 ## Next steps
 

--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -11,7 +11,7 @@ Helm simplifies the installation of Percona Everest. With this guide, you'll be 
 Percona Helm charts can be found in [percona/percona-helm-charts]( https://github.com/percona/percona-helm-charts/tree/main/charts/everest){:target="_blank"} repository in Github.
 
 !!! info "Alternative installation method"
-    If you prefer an alternative method, you can [install Percona Everest using the CLI](install/installEverest.md).
+    If you prefer an alternative method, you can [install Percona Everest using everestctl](install/installEverest.md).
 
 ## Prerequisites
 
@@ -150,6 +150,8 @@ Once you have successfully installed Percona Everest, proceed with the following
 
         Percona Everest will be available at [http://127.0.0.1:8080](http://127.0.0.1:8080). This method is mostly useful for testing purposes. 
 
+!!! info "important"
+    If you installed Percona Everest using `helm`, make sure to uninstall it exclusively through `helm` for a seamless removal.
 
 ## Next steps
 

--- a/docs/uninstall/uninstallEverest.md
+++ b/docs/uninstall/uninstallEverest.md
@@ -1,4 +1,7 @@
-# Uninstall Percona Everest using the CLI
+# Uninstall Percona Everest using everestctl
+
+!!! info "important"
+    If you installed Percona Everest using `everestctl`, make sure to uninstall it exclusively through `everestctl` for a seamless removal.
 
 You can run the commands below to remove all Everest resources including:
 

--- a/docs/uninstall/uninstall_everest_helm.md
+++ b/docs/uninstall/uninstall_everest_helm.md
@@ -1,7 +1,8 @@
 # Uninstall Percona Everest using Helm
 
-!!! info "Important"
-    If you installed Percona Everest using Helm, make sure to uninstall it exclusively through Helm for a seamless removal.
+!!! info "important"
+    If you installed Percona Everest using `helm`, make sure to uninstall it exclusively through `helm` for a seamless removal.
+
 
 
 ## Uninstall the database namespaces

--- a/docs/uninstall/uninstall_everest_helm.md
+++ b/docs/uninstall/uninstall_everest_helm.md
@@ -1,9 +1,7 @@
 # Uninstall Percona Everest using Helm
 
 !!! info "important"
-    If you installed Percona Everest using `helm`, make sure to uninstall it exclusively through `helm` for a seamless removal.
-
-
+    If you installed Percona Everest using `helm` and need to uninstall it, make sure to uninstall it exclusively through `helm` for seamless removal.
 
 ## Uninstall the database namespaces
 

--- a/docs/uninstall/uninstall_everest_helm.md
+++ b/docs/uninstall/uninstall_everest_helm.md
@@ -1,6 +1,7 @@
 # Uninstall Percona Everest using Helm
 
-If you installed Everest using Helm, follow the instructions below to uninstall.
+!!! info "Important"
+    If you installed Percona Everest using Helm, make sure to uninstall it exclusively through Helm for a seamless removal.
 
 
 ## Uninstall the database namespaces


### PR DESCRIPTION
Add a note in the documentation stating that the same tool (Helm or CLI) should be used to install and uninstall Percona Everest.