### PR TITLE
Enhance the warning about GCR deprecation

### DIFF
--- a/docs/release-notes/Percona-Everest-1.4.0-(2025-01-07).md
+++ b/docs/release-notes/Percona-Everest-1.4.0-(2025-01-07).md
@@ -1,13 +1,6 @@
 # What's new in Percona Everest 1.4.0
 
-!!! warning
-    Google Container Registry (GCR) is scheduled to be deprecated and will officially shut down on March 18, 2025. All versions of Percona Everest prior to 1.4.0 depend on images hosted on GCR, meaning that downloading those images will fail after the shutdown date. We strongly recommend upgrading to Percona Everest version 1.4.0 as soon as possible. If you do not upgrade, Percona Everest will no longer function.
-
-    For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
-
-
-To begin your journey with Percona Everest, check out the [Quickstart Guide for Percona Everest](../quick-install.md).
-
+➡️ **New to Percona Everest?** Get started with our [Quickstart Guide](https://docs.percona.com/everest/quick-install.html).
 
 ??? info "Release summary at a glance"
 
@@ -16,11 +9,12 @@ To begin your journey with Percona Everest, check out the [Quickstart Guide for 
     | **1.**|[Helm charts](https://docs.percona.com/everest/release-notes/Percona-Everest-1.4.0-%282025-01-07%29.html#__tabbed_1_1)|Simplify your Percona Everest deployments with Helm|
     | **2.**|[Namespace management](https://docs.percona.com/everest/release-notes/Percona-Everest-1.4.0-%282025-01-07%29.html#__tabbed_1_2)|Manage your namespaces with new everestctl commands|
     | **3.**|[Improved edit database flow](https://docs.percona.com/everest/release-notes/Percona-Everest-1.4.0-%282025-01-07%29.html#__tabbed_1_3)|Improved edit database flow for a more streamlined user experience|
-    | **4.**|[Operators support](https://docs.percona.com/everest/release-notes/Percona-Everest-1.4.0-%282025-01-07%29.html#__tabbed_1_4)|Support for [Percona Operator for MongoDB v1.18.0](https://docs.percona.com/percona-operator-for-mongodb/RN/Kubernetes-Operator-for-PSMONGODB-RN1.18.0.html){:target="_blank"}) (PSMDB) and [Percona Operator for PostgreSQL v2.5.0](https://docs.percona.com/percona-operator-for-postgresql/2.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.5.0.html){:target="_blank"} (PG)|
-    | **5.**|[New features](https://docs.percona.com/everest/release-notes/Percona-Everest-1.3.0-%282024-11-18%29.html#new-features)|Check out the new features introduced in Percona Everest 1.4.0|
-    | **6.**|[Improvements](https://docs.percona.com/everest/release-notes/Percona-Everest-1.3.0-%282024-11-18%29.html#improvements)|Discover all the enhancements featured in Percona Everest 1.4.0|
-    | **7.**|[Bugs](https://docs.percona.com/everest/release-notes/Percona-Everest-1.3.0-%282024-11-18%29.html#bugs)|Find out about all the bugs fixed in Percona Everest 1.4.0|
-    | **8.**|[Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.3.0-%282024-11-18%29.html#known-limitations)|Discover all the known limitations in Percona Everest 1.4.0|
+    | **4.**|[Operators support](https://docs.percona.com/everest/release-notes/Percona-Everest-1.4.0-%282025-01-07%29.html#__tabbed_1_4)|Support for [Percona Operator for MongoDB v1.18.0](https://docs.percona.com/percona-operator-for-mongodb/RN/Kubernetes-Operator-for-PSMONGODB-RN1.18.0.html){:target="_blank"} (PSMDB) and [Percona Operator for PostgreSQL v2.5.0](https://docs.percona.com/percona-operator-for-postgresql/2.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.5.0.html){:target="_blank"} (PG)|
+    | **5.**|[Google Container Registry (GCR) deprecation](https://docs.percona.com/everest/release-notes/Percona-Everest-1.3.0-%282024-11-18%29.html#google-container-registry-gcr)|Deprecation of GCR starting **March 18, 2025**| 
+    | **6.**|[New features](https://docs.percona.com/everest/release-notes/Percona-Everest-1.3.0-%282024-11-18%29.html#new-features)|Check out the new features introduced in Percona Everest 1.4.0|
+    | **7.**|[Improvements](https://docs.percona.com/everest/release-notes/Percona-Everest-1.3.0-%282024-11-18%29.html#improvements)|Discover all the enhancements featured in Percona Everest 1.4.0|
+    | **8.**|[Bugs](https://docs.percona.com/everest/release-notes/Percona-Everest-1.3.0-%282024-11-18%29.html#bugs)|Find out about all the bugs fixed in Percona Everest 1.4.0|
+    | **.9**|[Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.3.0-%282024-11-18%29.html#known-limitations)|Discover all the known limitations in Percona Everest 1.4.0|
 
 
 ## Release highlights
@@ -69,6 +63,24 @@ To begin your journey with Percona Everest, check out the [Quickstart Guide for 
 
 
     Starting with Percona Everest 1.4.0, we are thrilled to announce that we have added support for PSMDB Operator v1.18.0 and PG operator v2.5.0.
+
+## Google Container Registry (GCR)
+
+!!! warning "GCR will be deprecated"
+    GCR is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**.
+
+    All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
+
+### Impact of GCR deprecation
+
+Percona Everest versions older than 1.4.0 will cease to function after this date.
+
+### Action required
+
+We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
+    
+For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
+
 
 ## New features
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -10,7 +10,7 @@
     | **1.**|[Role-based access control (RBAC) Generally Available (GA)](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_1)|RBAC is now GA with Percona Everest 1.5.0 |
     | **2.**|[RBAC: Integration with IdP groups](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_2)|Assign RBAC policies to user groups obtained from an external IdP|
     | **3.**|[Operators support](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_3)|Support for PXC operator 1.16.1 and PSMDB operator 1.19.1|
-    | **4.**|[Google Container Registry (GCR) deprecation](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#google-container-registry-gcr)|Deprecation of GCR Starting **March 18, 2025**|
+    | **4.**|[Google Container Registry (GCR) deprecation](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#google-container-registry-gcr)|Deprecation of GCR starting **March 18, 2025**|
     | **5.**|[New features](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#new-features)|Check out the new features introduced in Percona Everest 1.5.0|
     | **6.**|[Improvements](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#improvements)|Discover all the enhancements featured in Percona Everest 1.5.0|
     | **7.**|[Bugs](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#bugs)|Find out about all the bugs fixed in Percona Everest 1.5.0|

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -176,11 +176,11 @@ We have fixed an issue that prevented users from editing or adding monitoring to
 
 - All versions of Percona Everest prior to 1.4.0 depend on images hosted on Google Container Registry, meaning that downloading those images will fail after the shutdown date (March 18, 2025).
 
-**Action required** 
+    **Action required** 
 
-We strongly recommend upgrading to Percona Everest version 1.4.0 as soon as possible. If you do not upgrade, Percona Everest will no longer function.
+    To prevent Percona Everest from becoming inoperable, an urgent upgrade to version 1.4.0 or later is required.
     
-For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
+    For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
 
 - PSMDB Operator version 1.19.1 added support for MongoDB version 8.0. However, due to **potential issues with point-in-time recovery on MongoDB 8.0** when sharding is enabled, the recommended MongoDB version is still 7.0.
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -10,8 +10,7 @@
     | **1.**|[Role-based access control (RBAC) Generally Available (GA)](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_1)|RBAC is now GA with Percona Everest 1.5.0 |
     | **2.**|[RBAC: Integration with IdP groups](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_2)|Assign RBAC policies to user groups obtained from an external IdP|
     | **3.**|[Operators support](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_3)|Support for PXC operator 1.16.1 and PSMDB operator 1.19.1|
-
-    | **4.**|[Google Container Registry (GCR)](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#google-container-registry-gcr)|Note about deprecation of GCR starting from March 18, 2025|
+    | **4.**|[Google Container Registry (GCR) deprecation](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#google-container-registry-gcr)|Note about deprecation of GCR starting from **March 18, 2025**|
     | **5.**|[New features](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#new-features)|Check out the new features introduced in Percona Everest 1.5.0|
     | **6.**|[Improvements](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#improvements)|Discover all the enhancements featured in Percona Everest 1.5.0|
     | **7.**|[Bugs](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#bugs)|Find out about all the bugs fixed in Percona Everest 1.5.0|

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -75,10 +75,9 @@ All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Co
 
 Percona Everest versions older than 1.4.0 will cease to function after this date.
 
-## Action required
+### Action required
 
-!!! info "Important"
-    We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
+We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
     
 For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -1,7 +1,7 @@
 # What's new in Percona Everest 1.5.0
 
 !!! info "Important"
-    **Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations) section.
+    **Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations#) section.
 
 ➡️ **New to Percona Everest?** Get started with our [Quickstart Guide](https://docs.percona.com/everest/quick-install.html).
 
@@ -172,17 +172,24 @@ We have fixed an issue that prevented users from editing or adding monitoring to
 
 ## Known limitations
 
-- All versions of Percona Everest prior to 1.4.0 depend on images hosted on Google Container Registry, meaning that downloading those images will fail after the shutdown date (March 18, 2025).
+### GCR deprecation
 
-    **Action required** 
+All versions of Percona Everest prior to 1.4.0 depend on images hosted on Google Container Registry, meaning that downloading those images will fail after the shutdown date (March 18, 2025).
 
-    We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
+**Action required** 
+
+We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
     
-    For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
+For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
 
-- PSMDB Operator version 1.19.1 added support for MongoDB version 8.0. However, due to **potential issues with point-in-time recovery on MongoDB 8.0** when sharding is enabled, the recommended MongoDB version is still 7.0.
 
-- When restoring a database using Point-in-Time Recovery (PITR), you **cannot manually change the time** between the most recent successful backup and the latest PITR. If you attempt to enter the date and time manually, the system will automatically reset it to align with the latest PITR. However, if you select the date and time using the date picker, it works as expected.
+### Issues with PITR on MongoDB 8.0
+
+PSMDB Operator version 1.19.1 added support for MongoDB version 8.0. However, due to **potential issues with point-in-time recovery on MongoDB 8.0** when sharding is enabled, the recommended MongoDB version is still 7.0.
+
+### PITR: Manual time entry issues
+
+When restoring a database using Point-in-Time Recovery (PITR), you **cannot manually change the time** between the most recent successful backup and the latest PITR. If you attempt to enter the date and time manually, the system will automatically reset it to align with the latest PITR. However, if you select the date and time using the date picker, it works as expected.
 
 ## :rocket: Upgrade now
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -1,7 +1,7 @@
 # What's new in Percona Everest 1.5.0
 
 !!! info "Important"
-    **Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for March 18, 2025. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations) section.
+    **Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations) section.
 
 ➡️ **New to Percona Everest?** Get started with our [Quickstart Guide](https://docs.percona.com/everest/quick-install.html).
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -68,8 +68,9 @@
 ## Google Container Registry (GCR)
 
 
-!!! warning "~~GCR will be deprecated~~"
+!!! warning "GCR will be deprecated"
     GCR is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**.
+    
     All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
 
 ### Impact of GCR deprecation

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -71,13 +71,14 @@ GCR is set to be **deprecated**, with its official shutdown scheduled for **Marc
 
 All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
 
-**Impact** 
+### Impact of GCR deprecation
 
 Percona Everest versions older than 1.4.0 will cease to function after this date.
 
-**Action required** 
+## Action required
 
-We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
+!!! info "Important"
+    We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
     
 For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -10,10 +10,12 @@
     | **1.**|[Role-based access control (RBAC) Generally Available (GA)](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_1)|RBAC is now GA with Percona Everest 1.5.0 |
     | **2.**|[RBAC: Integration with IdP groups](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_2)|Assign RBAC policies to user groups obtained from an external IdP|
     | **3.**|[Operators support](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_3)|Support for PXC operator 1.16.1 and PSMDB operator 1.19.1|
-    | **4.**|[New features](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#new-features)|Check out the new features introduced in Percona Everest 1.5.0|
-    | **5.**|[Improvements](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#improvements)|Discover all the enhancements featured in Percona Everest 1.5.0|
-    | **6.**|[Bugs](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#bugs)|Find out about all the bugs fixed in Percona Everest 1.5.0|
-    | **7.**|[Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations)|Discover all the known limitations in Percona Everest 1.5.0|
+
+    | **4.**|[Google Container Registry (GCR)](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#google-container-registry-gcr)|Note about deprecation of GCR starting from March 18, 2025|
+    | **5.**|[New features](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#new-features)|Check out the new features introduced in Percona Everest 1.5.0|
+    | **6.**|[Improvements](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#improvements)|Discover all the enhancements featured in Percona Everest 1.5.0|
+    | **7.**|[Bugs](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#bugs)|Find out about all the bugs fixed in Percona Everest 1.5.0|
+    | **8.**|[Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations)|Discover all the known limitations in Percona Everest 1.5.0|
 
 
 ## Release highlights

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -178,7 +178,7 @@ We have fixed an issue that prevented users from editing or adding monitoring to
 
     **Action required** 
 
-    To prevent Percona Everest from becoming inoperable, an urgent upgrade to version 1.4.0 or later is required.
+    We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
     
     For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -65,11 +65,12 @@
 
     Starting with Percona Everest 1.5.0, we are thrilled to announce that we have added support for PSMDB Operator v1.19.1 and PXC Operator v1.16.1.
 
-## Google Container Registry (GCR) deprecation
+## Google Container Registry (GCR)
 
-GCR is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**.
 
-All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
+!!! warning "~~GCR will be deprecated~~"
+    GCR is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**.
+    All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
 
 ### Impact of GCR deprecation
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -10,7 +10,7 @@
     | **1.**|[Role-based access control (RBAC) Generally Available (GA)](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_1)|RBAC is now GA with Percona Everest 1.5.0 |
     | **2.**|[RBAC: Integration with IdP groups](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_2)|Assign RBAC policies to user groups obtained from an external IdP|
     | **3.**|[Operators support](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#__tabbed_1_3)|Support for PXC operator 1.16.1 and PSMDB operator 1.19.1|
-    | **4.**|[Google Container Registry (GCR) deprecation](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#google-container-registry-gcr)|Note about deprecation of GCR starting from **March 18, 2025**|
+    | **4.**|[Google Container Registry (GCR) deprecation](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#google-container-registry-gcr)|Deprecation of GCR Starting **March 18, 2025**|
     | **5.**|[New features](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#new-features)|Check out the new features introduced in Percona Everest 1.5.0|
     | **6.**|[Improvements](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#improvements)|Discover all the enhancements featured in Percona Everest 1.5.0|
     | **7.**|[Bugs](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#bugs)|Find out about all the bugs fixed in Percona Everest 1.5.0|

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -1,9 +1,7 @@
 # What's new in Percona Everest 1.5.0
 
 !!! info "Important"
-    **Google Container Registry (GCR) Deprecation**
-
-    Google Container Registry (GCR) is set to be deprecated, with its official shutdown scheduled for March 18, 2025. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations) section.
+    **Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for March 18, 2025. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations) section.
 
 ➡️ **New to Percona Everest?** Get started with our [Quickstart Guide](https://docs.percona.com/everest/quick-install.html).
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -67,7 +67,7 @@
 
 ## Google Container Registry (GCR) deprecation
 
-**Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**.
+GCR is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**.
 
 All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -195,7 +195,7 @@ PSMDB Operator version 1.19.1 added support for MongoDB version 8.0. However, du
 
 Use MongoDB version 7.0.
 
-### PITR: Manual time entry issues
+### PITR: Manual time entry limitation
 
 When restoring a database using Point-in-Time Recovery (PITR), you **cannot manually change the time** between the most recent successful backup and the latest PITR. If you attempt to enter the date and time manually, the system will automatically reset it to align with the latest PITR. 
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -67,10 +67,9 @@
 
 ## Google Container Registry (GCR)
 
-
 !!! warning "GCR will be deprecated"
     GCR is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**.
-    
+
     All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
 
 ### Impact of GCR deprecation

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -1,7 +1,7 @@
 # What's new in Percona Everest 1.5.0
 
 !!! info "Important"
-    **Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations#) section.
+    **Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations#gcr-deprecation) section.
 
 ➡️ **New to Percona Everest?** Get started with our [Quickstart Guide](https://docs.percona.com/everest/quick-install.html).
 
@@ -172,9 +172,13 @@ We have fixed an issue that prevented users from editing or adding monitoring to
 
 ## Known limitations
 
-### GCR deprecation
+### Google Container Registry (GCR) Deprecation
 
-All versions of Percona Everest prior to 1.4.0 depend on images hosted on Google Container Registry, meaning that downloading those images will fail after the shutdown date (March 18, 2025).
+All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
+
+**Impact** 
+
+Percona Everest versions older than 1.4.0 will cease to function after this date.
 
 **Action required** 
 
@@ -185,11 +189,19 @@ For more details, refer to the [Container Registry Deprecation documentation](ht
 
 ### Issues with PITR on MongoDB 8.0
 
-PSMDB Operator version 1.19.1 added support for MongoDB version 8.0. However, due to **potential issues with point-in-time recovery on MongoDB 8.0** when sharding is enabled, the recommended MongoDB version is still 7.0.
+PSMDB Operator version 1.19.1 added support for MongoDB version 8.0. However, due to **potential issues with point-in-time recovery on MongoDB 8.0** when sharding is enabled, 
+
+**Action required**
+
+Use MongoDB version 7.0.
 
 ### PITR: Manual time entry issues
 
-When restoring a database using Point-in-Time Recovery (PITR), you **cannot manually change the time** between the most recent successful backup and the latest PITR. If you attempt to enter the date and time manually, the system will automatically reset it to align with the latest PITR. However, if you select the date and time using the date picker, it works as expected.
+When restoring a database using Point-in-Time Recovery (PITR), you **cannot manually change the time** between the most recent successful backup and the latest PITR. If you attempt to enter the date and time manually, the system will automatically reset it to align with the latest PITR. 
+
+**Action required**
+
+Use the date picker to select the desired date and time for PITR restore.
 
 ## :rocket: Upgrade now
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -3,14 +3,7 @@
 !!! info "Important"
     **Google Container Registry (GCR) Deprecation**
 
-    Google Container Registry (GCR) is scheduled to be deprecated and will officially shut down on March 18, 2025. All versions of Percona Everest prior to 1.4.0 depend on images hosted on GCR, meaning that downloading those images will fail after the shutdown date.
-
-    **Action required** 
-
-    We strongly recommend upgrading to Percona Everest version 1.4.0 as soon as possible. If you do not upgrade, Percona Everest will no longer function.
-    
-    For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
-
+    Google Container Registry (GCR) is set to be deprecated, with its official shutdown scheduled for March 18, 2025. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations) section.
 
 ➡️ **New to Percona Everest?** Get started with our [Quickstart Guide](https://docs.percona.com/everest/quick-install.html).
 
@@ -180,6 +173,14 @@ We have fixed an issue that prevented users from editing or adding monitoring to
 
 
 ## Known limitations
+
+- All versions of Percona Everest prior to 1.4.0 depend on images hosted on Google Container Registry, meaning that downloading those images will fail after the shutdown date (March 18, 2025).
+
+**Action required** 
+
+We strongly recommend upgrading to Percona Everest version 1.4.0 as soon as possible. If you do not upgrade, Percona Everest will no longer function.
+    
+For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
 
 - PSMDB Operator version 1.19.1 added support for MongoDB version 8.0. However, due to **potential issues with point-in-time recovery on MongoDB 8.0** when sharding is enabled, the recommended MongoDB version is still 7.0.
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -1,8 +1,5 @@
 # What's new in Percona Everest 1.5.0
 
-!!! info "Important"
-    **Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**. For more details, refer to the [Known limitations](https://docs.percona.com/everest/release-notes/Percona-Everest-1.5.0-%282025-03-04%29.html#known-limitations#gcr-deprecation) section.
-
 ➡️ **New to Percona Everest?** Get started with our [Quickstart Guide](https://docs.percona.com/everest/quick-install.html).
 
 
@@ -67,6 +64,22 @@
     ### Support for PSMDB 1.19.1 and PXC 1.16.1
 
     Starting with Percona Everest 1.5.0, we are thrilled to announce that we have added support for PSMDB Operator v1.19.1 and PXC Operator v1.16.1.
+
+## Google Container Registry (GCR) deprecation
+
+**Google Container Registry** (GCR) is set to be **deprecated**, with its official shutdown scheduled for **March 18, 2025**.
+
+All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
+
+**Impact** 
+
+Percona Everest versions older than 1.4.0 will cease to function after this date.
+
+**Action required** 
+
+We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
+    
+For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
 
 
 ## New features
@@ -172,24 +185,9 @@ We have fixed an issue that prevented users from editing or adding monitoring to
 
 ## Known limitations
 
-### Google Container Registry (GCR) Deprecation
-
-All Percona Everest versions prior to 1.4.0 depend on images hosted on Google Container Registry (GCR). These images will become unavailable after the shutdown date: **March 18, 2025**.
-
-**Impact** 
-
-Percona Everest versions older than 1.4.0 will cease to function after this date.
-
-**Action required** 
-
-We strongly recommend upgrading to Percona Everest version 1.4.0 or later as soon as possible. If you do not upgrade, Percona Everest will no longer function.
-    
-For more details, refer to the [Container Registry Deprecation documentation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown){:target="_blank"}.
-
-
 ### Issues with PITR on MongoDB 8.0
 
-PSMDB Operator version 1.19.1 added support for MongoDB version 8.0. However, due to **potential issues with point-in-time recovery on MongoDB 8.0** when sharding is enabled, 
+PSMDB Operator version 1.19.1 added support for MongoDB version 8.0. However, due to **potential issues with point-in-time recovery on MongoDB 8.0** when sharding is enabled, the recommended MongoDB version is still 7.0.
 
 **Action required**
 

--- a/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
+++ b/docs/release-notes/Percona-Everest-1.5.0-(2025-03-04).md
@@ -1,6 +1,6 @@
 # What's new in Percona Everest 1.5.0
 
-!!! warning
+!!! info "Important"
     **Google Container Registry (GCR) Deprecation**
 
     Google Container Registry (GCR) is scheduled to be deprecated and will officially shut down on March 18, 2025. All versions of Percona Everest prior to 1.4.0 depend on images hosted on GCR, meaning that downloading those images will fail after the shutdown date.


### PR DESCRIPTION
Update the GCR deprecation warning to adopt a milder tone so that users are not overwhelmed.