### PR TITLE
UI postgreSQL PITR limitations

### DIFF
--- a/docs/reference/known_limitations.md
+++ b/docs/reference/known_limitations.md
@@ -125,9 +125,11 @@ The default **uploadInterval** values for different databases are as follows:
 
 ### PostgreSQL limitation for PITR
 
-When performing point-in-time recovery (PITR) for PostgreSQL, it is important to consider the following limitation:
+When performing point-in-time recovery (PITR) for PostgreSQL, it is important to consider the following limitations:
 
-You may encounter issues with point-in-time recovery (PITR) when attempting to recover the database after the last transaction. PITR can get stuck in the **Restoring** state.
+- The Edit button in the UI for PITR is always disabled for PostgreSQL. However, PITR is still enabled automatically once a backup or a backup schedule exists.
+
+- You may encounter issues with point-in-time recovery (PITR) when attempting to recover the database after the last transaction. PITR can get stuck in the **Restoring** state.
 
 **Check the timestamp of the last transaction**
 

--- a/docs/reference/known_limitations.md
+++ b/docs/reference/known_limitations.md
@@ -127,7 +127,7 @@ The default **uploadInterval** values for different databases are as follows:
 
 When performing point-in-time recovery (PITR) for PostgreSQL, it is important to consider the following limitations:
 
-- The Edit button in the UI for PITR is always disabled for PostgreSQL. However, PITR is still enabled automatically once a backup or a backup schedule exists.
+- The Edit button for PITR in the UI is always disabled for PostgreSQL. However, PITR is automatically enabled once a backup or backup schedule is created.
 
 - You may encounter issues with point-in-time recovery (PITR) when attempting to recover the database after the last transaction. PITR can get stuck in the **Restoring** state.
 


### PR DESCRIPTION
Adding a new limitation about the UI in PostgreSQL PITR
<img width="236" alt="Screenshot 2025-04-07 at 11 31 56" src="https://github.com/user-attachments/assets/515cf101-9b6c-4c05-bb30-b18c184236a2" />
