### PR TITLE
Fix dataimporters s3 support statement

### DIFF
--- a/docs/backups_and_restore/dataimporters/overview.md
+++ b/docs/backups_and_restore/dataimporters/overview.md
@@ -78,6 +78,20 @@ Here are some common scenarios for importing database backups into Percona Evere
 
 There are a few limitations to be aware of when importing external database backups:
 
+- This feature **only** supports backups created **using Percona Operators**. Backups created by other tools directly in an S3 bucket are not supported.
+
+    ??? example "Example"
+
+        **Supported**
+
+        - Backups created via Percona Operator for MySQL or MongoDB
+        - Stored in S3-compatible object storage
+
+        **Unsupported**
+
+        - Backups taken by third-party tools
+        - Direct uploads to S3 without using Percona Operator
+
 - Percona Everest 1.8.0 **does not guarantee** successful imports for physical backups because it lacks an encryption key configuration. Although some cases may work depending on the backup method and environment, there is currently no official support for this feature.
 
 - Certain import methods require database user credentials that exactly match those from the source system. Since Percona Everest does not validate these credentials, you must ensure they are **accurate** before starting the import.

--- a/docs/backups_and_restore/dataimporters/overview.md
+++ b/docs/backups_and_restore/dataimporters/overview.md
@@ -84,8 +84,8 @@ There are a few limitations to be aware of when importing external database back
 
         **Supported**
 
-        - Backups created via Percona Operator for MySQL or MongoDB
-        - Stored in S3-compatible object storage
+        - Backups created via Percona Operator for MySQL, PostgreSQL, or MongoDB
+        - Stored in S3-compatible storage
 
         **Unsupported**
 

--- a/docs/backups_and_restore/dataimporters/pg_dataimporter.md
+++ b/docs/backups_and_restore/dataimporters/pg_dataimporter.md
@@ -5,7 +5,10 @@ The `everest-percona-pg-operator` dataimporter allows you to import backups take
 
 ##  Prerequisites
 
-- Backup taken using the Percona PostgreSQL operator stored in an S3-compatible storage bucket
+- Backup taken **only** using the Percona PostgreSQL operator stored in an S3-compatible storage bucket
+
+    !!! note
+        Backups created by other tools directly in an S3 bucket are not supported.
 
 - Credentials to access the S3 bucket (`AccessKeyID` and `SecretAccessKey`)
 

--- a/docs/backups_and_restore/dataimporters/psmdb_dataimporter.md
+++ b/docs/backups_and_restore/dataimporters/psmdb_dataimporter.md
@@ -5,7 +5,7 @@ The `everest-percona-psmdb-operator` data importer allows you to import backups 
 
 ##  Prerequisites
 
-- Backup taken **only** using the Percona MongoDB Operator stored in an S3-compatible storage bucket
+- Backups taken **only** using the Percona MongoDB Operator stored in an S3-compatible storage bucket
 
     !!! note
         Backups created by other tools directly in an S3 bucket are not supported.

--- a/docs/backups_and_restore/dataimporters/psmdb_dataimporter.md
+++ b/docs/backups_and_restore/dataimporters/psmdb_dataimporter.md
@@ -5,7 +5,11 @@ The `everest-percona-psmdb-operator` data importer allows you to import backups 
 
 ##  Prerequisites
 
-- Backup taken using the Percona MongoDB Operator stored in an S3-compatible storage bucket
+- Backup taken **only** using the Percona MongoDB Operator stored in an S3-compatible storage bucket
+
+    !!! note
+        Backups created by other tools directly in an S3 bucket are not supported.
+
 - Credentials to access the S3 bucket (`AccessKeyID` and `SecretAccessKey`)
 - System user credentials from the source cluster. For more details, refer to the [Percona Operator for MongoDB user documentation](  https://docs.percona.com/percona-operator-for-mongodb/users.html?h=user#system-users){:target="_blank"}.
 

--- a/docs/backups_and_restore/dataimporters/pxc_dataimporter.md
+++ b/docs/backups_and_restore/dataimporters/pxc_dataimporter.md
@@ -4,7 +4,11 @@ The `everest-percona-pxc-operator` dataimporter allows you to import backups tak
 
 ##  Prerequisites
 
-- Backup taken using the Percona MongoDB Operator stored in an S3-compatible storage bucket
+- Backup taken only using the Percona Operator for MySQL (XtraDB)stored in an S3-compatible storage bucket. Backups created by other tools directly in an S3 bucket are not supported.
+
+    !!! note
+        Backups created by other tools directly in an S3 bucket are not supported.
+
 - Credentials to access the S3 bucket (`AccessKeyID` and `SecretAccessKey`)
 - System user credentials from the source cluster. For more details, refer to the [Percona Operator for MySQL user documentation](  https://docs.percona.com/percona-operator-for-mysql/pxc/users.html?h=user#system-users){:target="_blank"}.
 

--- a/docs/backups_and_restore/dataimporters/pxc_dataimporter.md
+++ b/docs/backups_and_restore/dataimporters/pxc_dataimporter.md
@@ -4,7 +4,7 @@ The `everest-percona-pxc-operator` dataimporter allows you to import backups tak
 
 ##  Prerequisites
 
-- Backup taken only using the Percona Operator for MySQL (XtraDB)stored in an S3-compatible storage bucket. Backups created by other tools directly in an S3 bucket are not supported.
+- Backups taken **only** using the Percona Operator for MySQL (XtraDB) stored in an S3-compatible storage bucket.
 
     !!! note
         Backups created by other tools directly in an S3 bucket are not supported.


### PR DESCRIPTION
Update the database import documentation to specify that backups taken by any tool directly in an S3 bucket are not supported. The database import only supports backups taken by Percona Operators.