### PR TITLE
rollback_for_DB_upgrades

### DIFF
--- a/docs/upgrade/mongodb_major_upgrades.md
+++ b/docs/upgrade/mongodb_major_upgrades.md
@@ -4,7 +4,6 @@
     If you encounter an issue while upgrading your database version, there is **no option to roll back**. In this case, you must **manually diagnose and resolve** the problem.
 
 
-
 ## MongoDB: Major version upgrades
 
 Starting with Percona Everest 1.6.0, you can upgrade your MongoDB database major versions, allowing upgrades with minimal downtime and disruption.

--- a/docs/upgrade/mongodb_major_upgrades.md
+++ b/docs/upgrade/mongodb_major_upgrades.md
@@ -1,5 +1,9 @@
 # MongoDB: Major version upgrades
 
+!!! warning
+    When upgrading Percona Everest, if an issue arises, there is **no rollback option**. In that situation, you must **manually diagnose and resolve** the issue before attempting the upgrade again.
+
+
 Starting with Percona Everest 1.6.0, you can upgrade your MongoDB database major versions, allowing upgrades with minimal downtime and disruption.
 
 !!! note

--- a/docs/upgrade/mongodb_major_upgrades.md
+++ b/docs/upgrade/mongodb_major_upgrades.md
@@ -1,7 +1,7 @@
 # Database engine upgrades
 
 !!! warning
-    When upgrading Percona Everest, if an issue arises, there is **no rollback option**. In that situation, you must **manually diagnose and resolve** the issue before attempting the upgrade again.
+     If an issue arises when upgrading your database engine, there is **no rollback option**. In that situation, you must **manually diagnose and resolve** the issue.
 
 
 ## MongoDB: Major version upgrades

--- a/docs/upgrade/mongodb_major_upgrades.md
+++ b/docs/upgrade/mongodb_major_upgrades.md
@@ -1,13 +1,15 @@
-# MongoDB: Major version upgrades
+# Database engine upgrades
 
 !!! warning
     When upgrading Percona Everest, if an issue arises, there is **no rollback option**. In that situation, you must **manually diagnose and resolve** the issue before attempting the upgrade again.
 
 
+## MongoDB: Major version upgrades
+
 Starting with Percona Everest 1.6.0, you can upgrade your MongoDB database major versions, allowing upgrades with minimal downtime and disruption.
 
-!!! note
-    PostgreSQL and MySQL support only minor engine upgrades.
+!!! info "Important"
+    PostgreSQL and MySQL support only **minor** engine upgrades.
 
 ## Before you upgrade
 

--- a/docs/upgrade/mongodb_major_upgrades.md
+++ b/docs/upgrade/mongodb_major_upgrades.md
@@ -1,7 +1,8 @@
 # Database engine upgrades
 
 !!! warning
-     If an issue arises when upgrading your database engine, there is **no rollback option**. In that situation, you must **manually diagnose and resolve** the issue.
+    If you encounter an issue while upgrading your database engine, there is **no option to roll back**. In this case, you must **manually diagnose and resolve** the problem.
+
 
 
 ## MongoDB: Major version upgrades

--- a/docs/upgrade/mongodb_major_upgrades.md
+++ b/docs/upgrade/mongodb_major_upgrades.md
@@ -1,7 +1,7 @@
 # Database engine upgrades
 
 !!! warning
-    If you encounter an issue while upgrading your database engine, there is **no option to roll back**. In this case, you must **manually diagnose and resolve** the problem.
+    If you encounter an issue while upgrading your database version, there is **no option to roll back**. In this case, you must **manually diagnose and resolve** the problem.
 
 
 


### PR DESCRIPTION
Add a note that if an upgrade fails, there is no rollback option. Users will need to manually identify the issue and resolve it.