### PR TITLE
Fix the incorrect command in NodePort

### DIFF
--- a/docs/install/installEverest.md
+++ b/docs/install/installEverest.md
@@ -159,7 +159,7 @@ To install and provision Percona Everest to Kubernetes:
                     
             ```sh
             helm install percona-everest percona/everest \
-            --set service.type=LoadBalancer
+            --set service.type=NodePort
             ```
 
         2. The following command displays the port assigned by Kubernetes to the everest service, which is `32349` in this case.


### PR DESCRIPTION
Incorrect command in NodePort documentation for accessing Everest **UI/API**. 

For details, see the following ticket:


https://perconadev.atlassian.net/browse/EVEREST-2310