### PR TITLE
Split-Horizon DNS feature for PSMDB

### DIFF
--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -220,6 +220,8 @@ nav:
       - Load balancer overview: networking/load_balancer.md
       - Load balancer scenarios: networking/load_balancer_scenarios.md
       - Configure load balancer: networking/load_balancer_config.md
+      - Split-Horizon DNS: networking/split_horizon_dns.md
+
 
 
   - Back up and restore data: 


### PR DESCRIPTION
Document the **Split-Horizon DNS feature for PSMDB**. For more details, see the following document:

https://www.notion.so/percona/Split-Horizon-DNS-feature-for-PSMDB-27f674d091f3806b9d46dffaa7e24866