### PR TITLE
missing value olm.install in OpenShift doc

### DIFF
--- a/docs/install/install_everest_openshift.md
+++ b/docs/install/install_everest_openshift.md
@@ -17,6 +17,7 @@ Here are the steps to install Percona Everest with OpenShift compatibility enabl
         --create-namespace \
         --set compatibility.openshift=true \
         --set dbNamespace.compatibility.openshift=true \
+        --set olm.install=false \
         --set kube-state-metrics.securityContext.enabled=false \
         --set kube-state-metrics.rbac.create=false
     ```


### PR DESCRIPTION
Deploy procedure on OpenShift is missing the
--set olm.install=false \
value, while instead is needed and documented in
https://github.com/percona/percona-helm-charts/blob/main/charts/everest/docs/openshift.md