### PR TITLE
Changing the banner to be vendor neutral

### DIFF
--- a/overrides/partials/banner.html
+++ b/overrides/partials/banner.html
@@ -1,9 +1,10 @@
 <div data-banner="data-banner">
-    <p>
-        <svg style="display:block;margin:-1em 0 0.75em" width="78" height="69" viewBox="0 0 78 69" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M39 5C22.43 5 9 18.43 9 35C9 51.57 22.43 65 39 65C55.57 65 69 51.57 69 35C69 18.43 55.57 5 39 5ZM40.5 54.5H37.5V51.5H40.5V54.5ZM46.61 35.84L45.26 37.22C44.18 38.3 43.5 39.5 43.5 42.5H37.5V41C37.5 37.69 38.85 34.69 41.03 32.51L42.89 30.62C44 29.54 44.64 28.04 44.64 26.37C44.64 23.06 41.94 20.37 38.63 20.37C35.32 20.37 32.62 23.06 32.62 26.37H26.62C26.62 19.74 32 14.37 38.63 14.37C45.26 14.37 50.63 19.74 50.63 26.37C50.64 28.98 49.58 31.33 47.85 33.02L46.61 35.84Z" fill="currentColor"/>
-        </svg>
-    </p>
+ <svg xmlns="http://www.w3.org/2000/svg" height="48px" viewBox="0 0 24 24" width="48px" fill="currentColor"
+        style="opacity: 0.8;">
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path
+            d="M11 23.59v-3.6c-5.01-.26-9-4.42-9-9.49C2 5.26 6.26 1 11.5 1S21 5.26 21 10.5c0 4.95-3.44 9.93-8.57 12.4l-1.43.69zM11.5 3C7.36 3 4 6.36 4 10.5S7.36 18 11.5 18H13v2.3c3.64-2.3 6-6.08 6-9.8C19 6.36 15.64 3 11.5 3zm-1 11.5h2v2h-2zm2-1.5h-2c0-3.25 3-3 3-5 0-1.1-.9-2-2-2s-2 .9-2 2h-2c0-2.21 1.79-4 4-4s4 1.79 4 4c0 2.5-3 2.75-3 5z" />
+    </svg>
     <p>Get enterprise-grade support and services for OpenEverest from certified partners, or join community.</p>
 
     <div class="actions">


### PR DESCRIPTION
As we are moving towards vendor neutral project, we need to change the banner. Now it links to /support page of the project, where users can choose the vendor or join community.