### PR TITLE
Update features to fix links

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -11,8 +11,8 @@ Some of the key features of OpenEverest are:
 ## Database provisioning
 
 * **[Horizontal and vertical scaling](use/scaling.md)**: OpenEverest enables you to adapt to your application's demands using horizontal scaling for multi-node deployments or vertical scaling for single-node setups. With OpenEverest, you have the power to manage resources and ensure your databases are performing at their best.
-* **Database storage class support**: OpenEverest tailors your storage needs efficiently by leveraging its database storage class support. Furthermore, it allocates resources efficiently while maintaining optimal performance and cost.    
-* **[Disaster recovery capabilities](use/createBackups/CreateOnDemand.md)**: OpenEverest prioritizes data protection with a comprehensive disaster recovery suite. Create on-demand backups, seamlessly restore existing databases, or create new ones from backups to ensure that your data is protected.
+* **Database storage class support**: OpenEverest tailors your storage needs efficiently by leveraging its database storage class support. Furthermore, it allocates resources efficiently while maintaining optimal performance and cost.
+* **[Disaster recovery capabilities](backups_and_restore/createBackups/CreateOnDemand.md)**: OpenEverest prioritizes data protection with a comprehensive disaster recovery suite. Create on-demand backups, seamlessly restore existing databases, or create new ones from backups to ensure that your data is protected.
 * **[Advanced configuration options](use/db_engine_config.md)**: OpenEverest gives fine-grained control of your database environment with advanced configuration features. You can manage external access permissions and optimize your database engine configuration.
 
 ## Database management


### PR DESCRIPTION
The Disaster Recovery Capabilities link in [features.html](https://openeverest.io/documentation/current/features.html) sends you to [this link](https://openeverest.io/documentation/current/use/createBackups/CreateOnDemand.md) which is a 404.

It appears to have been broken in 52e02dded118a7efc8b5b86a1a2b4700b6dc8472