### PR TITLE
fix links to API spec

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -30,6 +30,6 @@ While you can achieve many tasks using either the OpenEverest user interface or 
 
 Check out our API endpoints for OpenEverest, where you can perform a wide range of functions.
 
-To access the API documentation, click [OpenEverest API](https://percona-everest.readme.io/){:target="_blank"}.
+To access the API documentation, click [OpenEverest API](https://openeverest.io/docs/api/){:target="_blank"}.
 
 

--- a/docs/api_rbac.md
+++ b/docs/api_rbac.md
@@ -30,7 +30,7 @@ The APIs have been updated with the following modifications:
 
         ```/v1/namespaces/{namespace}/backup-storages```
 
-        Check out the [API](https://percona-everest.readme.io/reference/getkubernetesclusterresources) documentation for more details.
+        Check out the [API](https://openeverest.io/docs/api/#/operations/getKubernetesClusterResources) documentation for more details.
 
 - The `.spec.allowedNamespaces` field has been deprecated. Access control for these resources is now managed through the RBAC policy.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Dive into our troubleshooting section designed to guide you through common issue
 
 Get ready to dive into our APIs and uncover their potential.
 
-[Dive into our APIs :material-arrow-right:](https://percona-everest.readme.io){ .md-button .md-button--primary }
+[Dive into our APIs :material-arrow-right:](https://openeverest.io/docs/api/){ .md-button .md-button--primary }
 
 </div>
 </div>

--- a/docs/troubleshoot/faq.md
+++ b/docs/troubleshoot/faq.md
@@ -12,7 +12,7 @@ Each `DatabaseEngine` indicates:
 - The operator version currently installed.
 - Compatible engine versions supported by that operator. 
 
-Refer to our [API documentation](https://percona-everest.readme.io/reference/getkubernetesclusterresources-1){:target="_blank"} for usage information.
+Refer to our [API documentation](https://openeverest.io/docs/api/#/operations/getKubernetesClusterResources){:target="_blank"} for usage information.
 
 ## Does OpenEverest provide logs for API calls?
 


### PR DESCRIPTION
The links to API spec are now going to legacy Percona readme.io website. We moved API spec to openeverest.io website. This PR fixes these links in the docs.