### PR TITLE
Helm chart command changes after the migration

### DIFF
--- a/docs/install/installEverest.md
+++ b/docs/install/installEverest.md
@@ -18,7 +18,7 @@ export KUBECONFIG=~/.kube/config
 ## Install OpenEverest
 
 !!! info "Important"
-    Starting from version 1.4.0, `everestctl` now uses the [Helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest){:target="_blank"} to install OpenEverest. To configure chart parameters during installation through `everestctl`, you can:
+    Starting from version 1.4.0, `everestctl` now uses the [Helm chart](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} to install OpenEverest. To configure chart parameters during installation through `everestctl`, you can:
 
     * Use the `--helm-.set` flag to specify individual parameter values.
     * Provide a values file with the `--helm.values` flag for bulk configuration.
@@ -124,7 +124,7 @@ To install and provision OpenEverest to Kubernetes:
         1. Use the following command to change the Everest service type to `LoadBalancer`:
                     
             ```sh
-            helm upgrade everest-system percona/everest \
+            helm upgrade everest openeverest/openeverest \
             --namespace everest-system \
             --reuse-values \
             --set server.service.type=LoadBalancer
@@ -156,7 +156,7 @@ To install and provision OpenEverest to Kubernetes:
 
                     
             ```sh
-            helm upgrade everest-system percona/everest \
+            helm upgrade everest openeverest/openeverest \
             --namespace everest-system \
             --reuse-values \
             --set server.service.type=NodePort

--- a/docs/install/install_everest_and_expose_via_ingress.md
+++ b/docs/install/install_everest_and_expose_via_ingress.md
@@ -19,7 +19,7 @@ An Ingress Controller is a Kubernetes component that manages external access to 
 
 === "Install OpenEverest using Helm"
 
-    Percona Helm charts are in the [percona/percona-helm-charts]( https://github.com/percona/percona-helm-charts/tree/main/charts/everest){:target="_blank"} repository on GitHub.
+    OpenEverest Helm charts are in the [openeverest/helm-charts](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} repository on GitHub.
 
     Here are the steps to install OpenEverest and deploy additional database namespaces:
     {.power-number}
@@ -27,14 +27,14 @@ An Ingress Controller is a Kubernetes component that manages external access to 
     1. Add the Percona Helm repository:
 
         ```sh
-        helm repo add percona https://percona.github.io/percona-helm-charts/
+        helm repo add openeverest https://openeverest.github.io/helm-charts/
         helm repo update
         ```
 
     2. Install OpenEverest with **Ingress enabled**:
 
         ```sh
-        helm install everest percona/everest \
+        helm install everest openeverest/openeverest \
           -n everest-system \
           --set ingress.enabled=true \
           --set ingress.ingressClassName="" \
@@ -93,7 +93,7 @@ An Ingress Controller is a Kubernetes component that manages external access to 
             Install OpenEverest using this `YAML` file:
 
             ```sh
-            helm install everest percona/everest \
+            helm install everest openeverest/openeverest \
               -n everest-system \
               -f everest-values.yaml
             ```
@@ -103,7 +103,7 @@ An Ingress Controller is a Kubernetes component that manages external access to 
             Install OpenEverest with TLS enabled:
 
             ```sh
-            helm install everest-core percona/everest \
+            helm install everest openeverest/openeverest \
             --namespace everest-system \
             --create-namespace
             --set server.tls.enabled=true
@@ -139,7 +139,7 @@ An Ingress Controller is a Kubernetes component that manages external access to 
 
         ```sh
         helm install everest \
-        percona/everest-db-namespace \
+        openeverest/everest-db-namespace \
         --create-namespace \
         --namespace <DB namespace>
         ```
@@ -151,7 +151,7 @@ An Ingress Controller is a Kubernetes component that manages external access to 
 === "Install OpenEverest using everesctl"
 
     !!! info "Important"
-        Starting from version 1.4.0, `everestctl` now uses the [Helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest){:target="_blank"} to install OpenEverest. To configure chart parameters during installation through `everestctl`, you can:
+        Starting from version 1.4.0, `everestctl` now uses the [Helm chart](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} to install OpenEverest. To configure chart parameters during installation through `everestctl`, you can:
         
         * Use the `--helm-.set` flag to specify individual parameter values.
         * Provide a values file with the `--helm.values` flag for bulk configuration.

--- a/docs/install/install_everest_helm_charts.md
+++ b/docs/install/install_everest_helm_charts.md
@@ -2,7 +2,7 @@
 
 This section explains how to install OpenEverest using [Helm](https://helm.sh/){:target="_blank"} as an alternative to `everestctl`. Helm charts simplify the deployment process by packaging all necessary resources and configurations, making them ideal for automating and managing installations in Kubernetes environments.
 
-OpenEverest Helm charts can be found in [percona/percona-helm-charts]( https://github.com/percona/percona-helm-charts/tree/main/charts/everest){:target="_blank"} repository in Github.
+OpenEverest Helm charts can be found in [openeverest/helm-charts](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} repository in Github.
 
 !!! info "Important"
     If you installed OpenEverest using Helm, make sure to uninstall it exclusively through Helm for a seamless removal.
@@ -16,14 +16,14 @@ Here are the steps to install OpenEverest and deploy additional database namespa
 1. Add the OpenEverest Helm repository:
 
     ```sh
-    helm repo add percona https://percona.github.io/percona-helm-charts/
+    helm repo add openeverest https://openeverest.github.io/helm-charts/
     helm repo update
     ```
 
 2. Install OpenEverest:
 
     ```sh
-    helm install everest-core percona/everest \
+    helm install everest openeverest/openeverest \
     --namespace everest-system \
     --create-namespace
     ```
@@ -51,14 +51,14 @@ Here are the steps to install OpenEverest and deploy additional database namespa
     
 
         ```sh
-        helm install everest-core percona/everest --namespace=everest-system --create-namespace --set pmm.enabled=true
+        helm install everest-core openeverest/openeverest --namespace=everest-system --create-namespace --set pmm.enabled=true
         ```
 
 
         Install OpenEverest with TLS enabled:
 
             
-            helm install everest-core percona/everest \
+            helm install everest openeverest/openeverest \
             --namespace everest-system \
             --create-namespace
             --set server.tls.enabled=true
@@ -89,7 +89,7 @@ Here are the steps to install OpenEverest and deploy additional database namespa
         1. Run the following command:
                     
             ```sh
-            helm upgrade everest-core percona/everest \
+            helm upgrade everest-core openeverest/openeverest \
             --namespace everest-system \
             --reuse-values \
             --set server.service.type=LoadBalancer
@@ -123,7 +123,7 @@ Here are the steps to install OpenEverest and deploy additional database namespa
         1. Run the following command to change the Everest service type to `NodePort`:
 
             ```sh
-            helm upgrade everest-core percona/everest \
+            helm upgrade everest-core openeverest/openeverest \
             --namespace everest-system \
             --reuse-values \
             --set server.service.type=NodePort
@@ -192,7 +192,7 @@ Here are the steps to install OpenEverest and deploy additional database namespa
 
     ```sh
     helm install everest \
-    percona/everest-db-namespace \
+    openeverest/everest-db-namespace \
     --create-namespace \
     --namespace <DB namespace>
     ```
@@ -205,10 +205,10 @@ Here are the steps to install OpenEverest and deploy additional database namespa
 
 You can customize various parameters in the OpenEverest Helm charts for your deployment to meet your specific needs. Refer to the [Helm documentation](https://helm.sh/docs/chart_best_practices/values/){:target="_blank"} to discover how to configure these parameters.
 
-A few parameters are listed in the following table. For a detailed list of the parameters, see the [README](https://github.com/percona/percona-helm-charts/blob/main/charts/everest/README.md#configuration){:target="_blank"}.
+A few parameters are listed in the following table. For a detailed list of the parameters, see the [README](https://github.com/openeverest/helm-charts/blob/main/charts/everest/README.md#configuration){:target="_blank"}.
 
 
-**percona/everest chart**
+**openeverest/openeverest chart**
 
 |**Key**|**Type**|**Default**|**Description**|
 |------|---------|-----------|---------------|
@@ -216,7 +216,7 @@ A few parameters are listed in the following table. For a detailed list of the p
 |`server.oidc`|object|{}|OIDC configuration for Everest.</br></br> These settings are applied only during installation. To modify the settings after installation, you have to manually update the everest-settings `ConfigMap`.|
 
 
-**percona/everest-db-namespace subchart**
+**openeverest/everest-db-namespace subchart**
 
 |**Key**|**Type**|**Default**|**Description**|
 |-------|--------|-----------|---------------

--- a/docs/install/install_everest_openshift.md
+++ b/docs/install/install_everest_openshift.md
@@ -12,7 +12,7 @@ Here are the steps to install OpenEverest with OpenShift compatibility enabled:
 1. Run the following command:
 
     ```sh
-    helm install everest-core percona/everest \
+    helm install everest openeverest/openeverest \
         --namespace everest-system \
         --create-namespace \
         --set compatibility.openshift=true \
@@ -53,7 +53,7 @@ Here are the steps to install OpenEverest with OpenShift compatibility enabled:
 
     ```sh
     helm install everest \
-        percona/everest-db-namespace \
+        openeverest/everest-db-namespace \
         --create-namespace \
         --namespace everest \
         --set compatibility.openshift=true
@@ -77,10 +77,10 @@ Here are the steps to install OpenEverest with OpenShift compatibility enabled:
 
     === "Load Balancer"
 
-        1. Use the following command to change the Everest service type to `LoadBalancer`:
+        1. Use the following command to change the OpenEverest service type to `LoadBalancer`:
                     
             ```
-            helm install percona-everest percona/everest \
+            helm install everest openeverest/openeverest \
             --set service.type=LoadBalancer
             ```
                     

--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -2,7 +2,7 @@
 
 Helm simplifies the installation of OpenEverest. With this guide, you'll be up and running with OpenEverest in no time. However, we also have a comprehensive [installation guide](install/install_everest_helm_charts.md) that covers all possibilities.
 
-OpenEverest Helm charts can be found in [percona/percona-helm-charts](https://github.com/percona/percona-helm-charts/tree/main/charts/everest){:target="_blank"} repository in Github.
+OpenEverest Helm charts can be found in [openeverest/helm-charts](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} repository in Github.
 
 !!! info "Alternative installation method"
     If you prefer an alternative method, you can [install OpenEverest using everestctl](install/installEverest.md).
@@ -58,7 +58,7 @@ To install OpenEverest using Helm follow these steps:
 1. Add the OpenEverest Helm repository.
 
     ```sh
-    helm repo add percona https://percona.github.io/percona-helm-charts/
+    helm repo add openeverest https://openeverest.github.io/helm-charts/
     helm repo update
     ```
 
@@ -66,7 +66,7 @@ To install OpenEverest using Helm follow these steps:
 
 
     ```sh
-    helm install everest-core percona/everest \
+    helm install everest openeverest/openeverest \
     --namespace everest-system \
     --create-namespace
     ```
@@ -89,7 +89,7 @@ To install OpenEverest using Helm follow these steps:
         1. Install OpenEverest:
 
             ```sh
-            helm install everest percona/everest \
+            helm install everest openeverest/openeverest \
               -n everest-system \
               --set ingress.enabled=true \
               --set ingress.ingressClassName="" \
@@ -134,7 +134,7 @@ To install OpenEverest using Helm follow these steps:
             Install OpenEverest using this file:
 
             ```sh
-            helm install everest percona/everest \
+            helm install everest openeverest/openeverest \
             -n everest-system \
             -f everest-values.yaml
             ```
@@ -144,7 +144,7 @@ To install OpenEverest using Helm follow these steps:
         Install OpenEverest with TLS enabled:
 
         ```sh
-        helm install everest-core percona/everest \
+        helm install everest openeverest/openeverest \
         --namespace everest-system \
         --create-namespace
         --set server.tls.enabled=true
@@ -183,7 +183,7 @@ Once you have successfully installed OpenEverest, proceed with the following ste
         1. Use the following command to change the Everest service type to `LoadBalancer`:
                                                 
             ```sh
-            helm install percona-everest percona/everest \
+            helm install everest openeverest/openeverest \
             --set service.type=LoadBalancer
             ```
             

--- a/docs/security/tls_setup.md
+++ b/docs/security/tls_setup.md
@@ -51,7 +51,7 @@ Here are the steps to set up the OpenEverest server using cert-manager:
 2. Install OpenEverest using the above values:
 
     ```sh
-    helm install everest-core percona/everest --create-namespace \
+    helm install everest-core openeverest/openeverest --create-namespace \
 	-n everest-system \
 	-f values.yaml
     ```
@@ -65,7 +65,7 @@ Here are the steps to set up the OpenEverest server using cert-manager:
      
 
     ```sh
-    helm install everest-core percona/everest --create-namespace \
+    helm install everest-core openeverest/openeverest --create-namespace \
 	-n everest-system \
 	--set server.tls.enabled=true
     ```
@@ -94,7 +94,7 @@ Here are the steps to set up the OpenEverest server using cert-manager:
     3. Install OpenEverest using the above values:
 
         ```sh
-        helm install everest-core percona/everest --create-namespace \
+        helm install everest-core openeverest/openeverest --create-namespace \
         -n everest-system \
         -f values.yaml
         ```

--- a/docs/troubleshoot/bitnami_container_catalog_changes.md
+++ b/docs/troubleshoot/bitnami_container_catalog_changes.md
@@ -74,7 +74,7 @@ You must **manually update your Helm charts** to use the new image. If you are o
 2. Upgrade the main OpenEverest chart (for example, the `everest-system` release) with its corresponding release name, namespace, and version:
 
     ```sh
-    helm upgrade everest-system percona/everest \
+    helm upgrade everest-system openeverest/openeverest \
     --reuse-values \
     --namespace everest-system \
     --version 1.8.1
@@ -94,7 +94,7 @@ You must **manually update your Helm charts** to use the new image. If you are o
     Execute the helm upgrade command for each `everest-db-namespace `chart identified in **step 1**.
 
     ```sh
-    helm upgrade a1 percona/everest-db-namespace \
+    helm upgrade a1 openeverest/everest-db-namespace \
     --reuse-values \
     --namespace a1 \
     --version 1.8.1
@@ -108,7 +108,7 @@ You must **manually update your Helm charts** to use the new image. If you are o
     ```
 
     ```sh
-    helm upgrade everest percona/everest-db-namespace \
+    helm upgrade everest openeverest/everest-db-namespace \
     --reuse-values \
     --namespace everest \
     --version 1.8.1
@@ -201,7 +201,7 @@ Follow these steps to fix the problem:
     Use the release name, namespace, and **APP VERSION** from the previous steps to upgrade the chart.
 
     ```sh
-    helm upgrade everest percona/everest-db-namespace \
+    helm upgrade everest openeverest/everest-db-namespace \
     --reuse-values \
     --namespace everest \
     --version 1.8.1

--- a/docs/troubleshoot/faq.md
+++ b/docs/troubleshoot/faq.md
@@ -58,7 +58,7 @@ OpenEverest doesn't deploy PMM (Percona Monitoring and Management). However, you
 
 We configure PMM agents in each DB deployment to communicate with an existing PMM server.
 
-The following table shows the [configurable parameters](https://github.com/percona/percona-helm-charts/tree/main/charts/everest#configuration){:target="_blank"} of OpenEverest chart and their default values.
+The following table shows the [configurable parameters](https://github.com/openeverest/helm-charts/tree/main/charts/everest#configuration){:target="_blank"} of OpenEverest chart and their default values.
 
 ### Monitoring configuration highlights:
 

--- a/docs/troubleshoot/installation_overview.md
+++ b/docs/troubleshoot/installation_overview.md
@@ -7,9 +7,9 @@ This page provides an overview of how OpenEverest is installed, the components i
 
 Starting with OpenEverest v1.4.0, the [everestctl](../install/installEverest.md) is a wrapper around two helm charts:
 
-- [everest-core](https://github.com/percona/percona-helm-charts/tree/main/charts/everest){:target="_blank"} 
+- [everest-core](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} 
 
-- [everest-db-namespace](https://github.com/percona/percona-helm-charts/tree/main/charts/everest/charts/everest-db-namespace){:target="_blank"}. 
+- [everest-db-namespace](https://github.com/openeverest/helm-charts/tree/main/charts/everest/charts/everest-db-namespace){:target="_blank"}. 
 
 The installation flow is as follows:
 {.power-number}
@@ -72,9 +72,9 @@ everestctl namespaces update [NAMESPACE]
 everestctl namespaces remove [NAMESPACE]
 ```
 
-For detailed information on managing namespaces, see the [Namespaces management](https://github.com/percona/percona-helm-charts/tree/main/charts/everest#4-deploy-additional-database-namespaces){:target="_blank"} section.
+For detailed information on managing namespaces, see the [Namespaces management](https://github.com/openeverest/helm-charts/tree/main/charts/everest#4-deploy-additional-database-namespaces){:target="_blank"} section.
 
-The [helm installation method](../install/install_everest_helm_charts.md) provides an identical flow to the one described above, with similar configuration options. Refer to the [helm chart documentation](https://github.com/percona/percona-helm-charts/tree/main/charts/everest){:target="_blank"} for a complete list of available [configuration options](https://github.com/percona/percona-helm-charts/tree/main/charts/everest#configuration){:target="_blank"}.
+The [helm installation method](../install/install_everest_helm_charts.md) provides an identical flow to the one described above, with similar configuration options. Refer to the [helm chart documentation](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} for a complete list of available [configuration options](https://github.com/openeverest/helm-charts/tree/main/charts/everest#configuration){:target="_blank"}.
 
 ## Server and operator workflow
 
@@ -100,7 +100,7 @@ Here's the database creation workflow in OpenEverest:
 Here’s the workflow for the database engine in OpenEverest:
 {.power-number}
 
-1. You can install the `everest-db-namespace` chart either as part of the initial installation or as a [separate step](https://github.com/percona/percona-helm-charts/tree/main/charts/everest#4-deploy-additional-database-namespaces).
+1. You can install the `everest-db-namespace` chart either as part of the initial installation or as a [separate step](https://github.com/openeverest/helm-charts/tree/main/charts/everest#4-deploy-additional-database-namespaces).
 2. OLM subscriptions are created for the operators chosen while installing the Helm chart.
 3. OLM **reconciles the Subscriptions** and creates an **InstallPlan**.
 4. The Helm chart creates a Kubernetes job called `everest-operators-installer` that waits for the `InstallPlan` to be created and approves it.

--- a/docs/upgrade/upgrade_with_helm.md
+++ b/docs/upgrade/upgrade_with_helm.md
@@ -21,6 +21,51 @@ OpenEverest consistently delivers updates that includes bug fixes, security enha
 kubectl label namespaces everest-system app.kubernetes.io/managed-by-
 ```
 
+## Migrate from the Percona Helm repository
+
+If you originally installed OpenEverest using the `percona` Helm repository, you need to perform a one-time migration to switch your existing releases to the new `openeverest` repository. This does not reinstall OpenEverest — it simply re-associates your existing Helm releases with the new chart source while preserving all your current configuration.
+
+To migrate, run the following commands:
+{.power-number}
+
+1. Add the new OpenEverest Helm repository:
+
+    ```sh
+    helm repo add openeverest https://openeverest.github.io/helm-charts/
+    ```
+
+2. Update your local Helm repository cache:
+
+    ```sh
+    helm repo update
+    ```
+
+3. Upgrade each release to use the chart from the new repository.
+
+    Upgrade the core components release:
+
+    ```sh
+    helm upgrade everest openeverest/openeverest \
+      --namespace everest-system \
+      --reuse-values
+    ```
+
+    If you have one or more database namespace releases, upgrade each one:
+
+    ```sh
+    helm upgrade <RELEASE_NAME> openeverest/everest-db-namespace \
+      --namespace <DB_NAMESPACE> \
+      --reuse-values
+    ```
+
+    Replace `<RELEASE_NAME>` and `<DB_NAMESPACE>` with your actual release name and namespace. To list all your current releases, run `helm list --all-namespaces`.
+
+4. (Optional) Remove the old Percona Helm repository once all releases have been migrated:
+
+    ```sh
+    helm repo remove percona
+    ```
+
 ## Upgrade CRDs
 
 In Helm v3, CRDs are not updated automatically during a Helm upgrade. You need to upgrade the CRDs manually.
@@ -30,7 +75,7 @@ To update the CRDs, run the following command:
 ```sh
 helm repo update
 helm upgrade --install everest-crds \
-    percona/everest-crds \
+    openeverest/everest-crds \
     --namespace everest-system \
     --take-ownership
 ```
@@ -69,7 +114,7 @@ To upgrade OpenEverest using Helm, run the following commands:
 1. Upgrade the Helm release for Everest (core components).
 
     ```sh
-    helm upgrade everest-core percona/everest --namespace everest-system --version "$VERSION"       
+    helm upgrade everest-core openeverest/openeverest --namespace everest-system --version "$VERSION"       
     ```
 
     where,
@@ -79,7 +124,7 @@ To upgrade OpenEverest using Helm, run the following commands:
 2. Upgrade the Helm release for the database namespace (if applicable):
 
     ```sh
-    helm upgrade everest percona/everest-db-namespace --namespace <DB namespace> --version "$VERSION"
+    helm upgrade everest openeverest/everest-db-namespace --namespace <DB namespace> --version "$VERSION"
     ```
 
     where,


### PR DESCRIPTION
OpenEverest used percona helm chart in percona/percona-helm-charts repo.

We moved those to a dedicated OpenEverest repo: https://github.com/openeverest/helm-charts

This PR fixes the docs to use the new repository + adds an info on how to migrate to new helm from the `percona` one.