### PR TITLE
Enable mike version selector and add GH Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,87 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g. 1.15.1)'
+        required: false
+      backfill:
+        description: 'Backfill ALL historical tags? (one-time setup)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          pip install -r requirements.txt
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Backfill all historical versions
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill }}
+        run: |
+          for tag in $(git tag -l 'v*' | sort -V); do
+            version="${tag#v}"
+            echo "Deploying historical version: $version"
+            git checkout "$tag"
+            mike deploy "$version" --update-aliases --branch gh-pages --push
+          done
+          git checkout main
+
+      - name: Determine version
+        id: version
+        if: ${{ !inputs.backfill }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#v}"
+            echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy with mike
+        if: ${{ !inputs.backfill }}
+        run: |
+          mike deploy ${{ steps.version.outputs.VERSION }} \
+            --push \
+            --update-aliases \
+            --branch gh-pages
+
+      - name: Set as default
+        if: ${{ !inputs.backfill }}
+        run: |
+          mike set-default ${{ steps.version.outputs.VERSION }} \
+            --push \
+            --branch gh-pages

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -139,7 +139,7 @@ plugins:
   # https://pypi.org/project/mkdocs-htmlproofer-plugin/
   #    htmlproofer: {}
   mike:
-    version_selector: false
+    version_selector: true
     css_dir: css
     javascript_dir: js
     canonical_version: null

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@
 INHERIT: mkdocs-base.yml
 
 
-site_url: https://openeverest.io/documentation/
+site_url: https://openeverest.github.io/everest-doc/
 
 
 #Google Analytics configuration 


### PR DESCRIPTION
## Summary

Part of https://github.com/openeverest/openeverest.github.io/issues/72.

This PR makes everest-doc self-deploying to GitHub Pages with a built-in version picker:

- **Version selector**: Enables mike's built-in version dropdown (`version_selector: false → true`). Users see a version picker in the docs nav, populated automatically from the `gh-pages` branch.
- **Deploy workflow**: New `deploy-pages.yml` runs `mike deploy <version>` on tag push and pushes versioned docs to the `gh-pages` branch. Includes a one-time backfill mode for historical versions.
- **site_url**: Updated to `https://openeverest.github.io/everest-doc/` so canonical URLs and sitemap point to the GitHub Pages site.