### PR TITLE
Update GitHub Actions token secret for good first issue workflow

### DIFF
--- a/.github/workflows/good-first-issue.yml
+++ b/.github/workflows/good-first-issue.yml
@@ -17,7 +17,7 @@ jobs:
           project-url: https://github.com/orgs/openeverest/projects/2
           
           # The secret name you will create in Step 2
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
           
           # Filter for your specific label
           labeled: good first issue


### PR DESCRIPTION
We used an outdated secret for good first issue workflow. Updating it to the project one.