### PR TITLE
Fix Mermaid diagram rendering and dark-mode contrast

### DIFF
--- a/docs/css/design.css
+++ b/docs/css/design.css
@@ -137,6 +137,7 @@
     --md-footer-bg-color--dark: var(--stone800);
 
     /* Code */
+    --md-code-fg-color: var(--white);
     --md-code-bg-color: var(--stone50);
     --md-code-bg-color: var(--stone800);
 

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -89,7 +89,11 @@ markdown_extensions:
   pymdownx.mark: {}
   pymdownx.smartsymbols: {}
   pymdownx.tilde: {}
-  pymdownx.superfences: {}
+  pymdownx.superfences:
+    custom_fences:
+      - name: mermaid
+        class: mermaid
+        format: !!python/name:pymdownx.superfences.fence_code_format
   pymdownx.tabbed:
     alternate_style: true
   pymdownx.tasklist:


### PR DESCRIPTION
## Summary
Fixes #364 

Fix Mermaid diagrams in the v2 documentation.

- Register `mermaid` as a custom `pymdownx.superfences` fence so Mermaid blocks render as diagrams instead of plain code.
- Use the existing OpenEverest dark-theme foreground token to ensure Mermaid labels and edges have sufficient contrast.

## Visual changes

### Before
<img width="1147" height="556" alt="image" src="https://github.com/user-attachments/assets/5056c4a4-1e98-4b38-bc6e-ce42a9690168" />


### After

<img width="1083" height="336" alt="image" src="https://github.com/user-attachments/assets/99d96b8a-e7b5-4413-8994-8bd58483f2e8" />

## Verification

- Ran `mkdocs build -f mkdocs.yml`.
- Verified the Providers diagram renders correctly at `/documentation/extend/providers.html`.
- Verified Mermaid rendering for:
  - `extend/index.html`
  - `extend/generic-plugins.html`
  - `release-notes/OpenEverest-2.0.0-dev.1-(2026-05-29).html`