### PR TITLE
Fix documentation spelling errors

### DIFF
--- a/docs/administer/Idp_groups_integration.md
+++ b/docs/administer/Idp_groups_integration.md
@@ -105,7 +105,7 @@ Take a look at the descriptions of the various fields in the table below:
     2. OKTA authenticates the user and provides an ID token that includes:
 
         - `openid` - User identifier (sub)
-        - `profile` - Users name, picure, and other profile data
+        - `profile` - Users name, picture, and other profile data
         - `email` - Verified email address
         - `groups` - User's group membership (ProjecTeam,Admins)
 
@@ -127,9 +127,6 @@ p, groupname, database-clusters, *, */
 
 For additional information, refer to the section on [assigning roles to users](../administer/rbac.md#assigning-roles-to-users) in RBAC.
 
-
-
-    
 
 
 

--- a/docs/administer/default_policies.md
+++ b/docs/administer/default_policies.md
@@ -45,7 +45,7 @@ Default anti-affinity prevents multiple DB Nodes or Proxies of the same cluster 
 - **PG Bouncer**: A lightweight connection pooler for PostgreSQL.
 
 
-The policy ensures separation (that is, allocate each DB cluster or component to a seperate node) between DB Nodes and PG Bouncers. 
+The policy ensures separation (that is, allocate each DB cluster or component to a separate node) between DB Nodes and PG Bouncers.
 
 ![!image](../images/pg_default_policy.png)
 
@@ -75,10 +75,6 @@ This policy is designed to prefer the placement of DB Nodes (replica set members
 
 
 
-
-
-
- 
 
 
 

--- a/docs/administer/rbac.md
+++ b/docs/administer/rbac.md
@@ -117,7 +117,7 @@ Below is a comprehensive table outlining the permissions available for various *
 
     === "Restores"
 
-        For restores, to new and existing databases, you should grant the following permisssions as well:
+        For restores, to new and existing databases, you should grant the following permissions as well:
 
         - Read `backups` (of the old DB)
         - Read `MonitoringConfig` (if the old DB has monitoring enabled)
@@ -171,7 +171,7 @@ In this section, we will explore some examples that demonstrate how to create po
     
     === "Namespace admin role" 
     
-        **Admin role for a single namepsace**
+        **Admin role for a single namespace**
 
         Let's set up an admin role with unrestricted privileges to all the resources in a single namespace called `namespaceA`.
 
@@ -196,8 +196,8 @@ In this section, we will explore some examples that demonstrate how to create po
             - **Database engines**: `Read` and `update` access
             - **Database clusters**: `All` access (read, create, update, delete)
             - **Database cluster backups**: `All` access (read, create, delete) 
-            - **Database cluster rstores**: `All` access (read, create, update, delete) 
-            - **Database clusters credentials**: `Read` acccess
+            - **Database cluster restores**: `All` access (read, create, update, delete)
+            - **Database clusters credentials**: `Read` access
             - **Backup storages**: `All` access (read, create, update, delete)
             - **Monitoring instances**: `All` access (read, create, update, delete)
             - **Load balancer configs**: `All` access (read, create, update, delete)
@@ -265,7 +265,7 @@ In this section, we will explore some examples that demonstrate how to create po
             - **Database cluster restores**: `Read` access
             - **Backup storages**: `Read` access
             - **Monitoring instances**: `Read` access
-            - **Database clusters credentials**: `Read` acccess
+            - **Database clusters credentials**: `Read` access
             - **Load balancer configs**: `Read` access
             - **Pod scheduling policies**: `Read` access
 
@@ -296,7 +296,7 @@ In this section, we will explore some examples that demonstrate how to create po
             - **Database clusters**: `All` access (read, create, update, delete)
             - **Database cluster backups**: `All` access (read, create, delete)
             - **Database cluster restores**: `All` access (read, create, update, delete)
-            - **Database clusters credentials**: `Read` acccess for **all** the databases       
+            - **Database clusters credentials**: `Read` access for **all** the databases
             - **Backup storages**: `Read` access to all the backup storages
             - **Monitoring instances**: `Read` access to all the monitoring instances
 
@@ -325,8 +325,8 @@ In this section, we will explore some examples that demonstrate how to create po
             - **Database clusters**: `All` access (read, create, update, delete) in namespace `namespaceA` only for database `databaseA`
             - **Database cluster backups**: `All` access (read, create, delete) in the namespace `namespaceA`
             - **Database cluster restores**: `All` access (read, create, update, delete) in the namespace `namespaceA`
-            - **Database clusters credentials**: `Read` acccess for **all** the databases       
-            - **Backup storages**: `Read` access to all the backup storagesin the namespace `namespaceA`
+            - **Database clusters credentials**: `Read` access for **all** the databases
+            - **Backup storages**: `Read` access to all the backup storages in the namespace `namespaceA`
             - **Monitoring instances**: `Read` access to all the monitoring instances in the namespace `namespaceA`
 
 
@@ -556,12 +556,8 @@ Starting from OpenEverest v1.2.0, breaking changes are being implemented to the 
 
 
 
+
+
     
     
   
-
-
-
-
-
-

--- a/docs/install/installEverest.md
+++ b/docs/install/installEverest.md
@@ -59,7 +59,7 @@ To install and provision OpenEverest to Kubernetes:
     - **Install OpenEverest using the headless mode**
         {.power-number}
 
-        1. Run the following command. You can set multiple namepaces in the headless mode. Replace `<namespace-name>` with the desired name for your namespace.
+        1. Run the following command. You can set multiple namespaces in the headless mode. Replace `<namespace-name>` with the desired name for your namespace.
             ```sh
             everestctl install --namespaces <namespace-name1>,<namespace-name2> --operator.mongodb=true --operator.postgresql=true --operator.mysql=true --skip-wizard
             ```

--- a/docs/reference/known_limitations.md
+++ b/docs/reference/known_limitations.md
@@ -104,7 +104,7 @@ Here are the limitations for OpenEverest:
 ## Upgrading operators
 
 - When you upgrade PostgreSQL operators to version 2.4.1, the database transitions to the **Initializing** state as part of the upgrade process. However, this **Initializing** state does not cause any downtime.
-- Since the PostgreSQL operator does not support major version upgrades, you cannot directly upgrade PostgreSQL 12.19 to 13.16. This limitation also prevents upgrading the PG operator itself. Morever, there is no built-in mechanism for transferring data from PostgreSQL 12.19 to 13.16, making migration a challenge.
+- Since the PostgreSQL operator does not support major version upgrades, you cannot directly upgrade PostgreSQL 12.19 to 13.16. This limitation also prevents upgrading the PG operator itself. Moreover, there is no built-in mechanism for transferring data from PostgreSQL 12.19 to 13.16, making migration a challenge.
 - When you upgrade PXC operators to version 1.15.0, single node MySQL databases will be restarted, resulting in downtime. However, it is worth noting that single node databases should not be used in production environments.
 
 ## Backups storage
@@ -293,4 +293,3 @@ everestctl settings oidc configure \
     Note: Replace `<your-app-client-id>` with your actual Microsoft Entra application (client) ID, and ensure the issuer-url points to the correct tenant.
 
 With this configuration, the access token will include `"aud": "<your-app-client-id>"`, and it will have a valid signature that OpenEverest can verify.
-

--- a/docs/use/multi-namespaces.md
+++ b/docs/use/multi-namespaces.md
@@ -35,7 +35,7 @@ The following holds true for multiple namespaces:
 - You can [install different operators](../administer/manage_namespaces.md#update-namespaces) in various namespaces using the `everestctl namespaces update [NAMESPACE]` command.
 
 
-??? example "Example: Configuring multiple namesapces and installing various operators within those namespaces"            
+??? example "Example: Configuring multiple namespaces and installing various operators within those namespaces"
     To install various operators in different namespaces, such as MongoDB and MySQL operator in namespace production, and PostgreSQL operator in namespace development, run the following commands:
     {.power-number}
 
@@ -80,6 +80,5 @@ For information on deploying a new database cluster in the namespace, see the [P
 
 
 
- 
 
 


### PR DESCRIPTION
## Summary

Correct spelling errors in the OpenEverest documentation.

- Fix namespace, permission, access, profile, and policy terminology typos.
- Correct two additional RBAC documentation typos.
- Make no functional, structural, or configuration changes.

## Verification

- Ran a spelling check on all changed Markdown files.
- Ran:

  ```bash
  mkdocs build -f mkdocs.yml