### PR TITLE
Fix PITR link on restore backup page

### DIFF
--- a/docs/backups_and_restore/RestoreBackup.md
+++ b/docs/backups_and_restore/RestoreBackup.md
@@ -32,7 +32,7 @@ To seamlessly resume PITR after a restore, make sure to run a new full backup. T
 ## Restore to a point-in-time recovery
 
 !!! warning
-    For PostgreSQL, point-in-time recovery (PITR) can get stuck in a **Restoring** state when you attempt to recover the database after the last transaction. See the [Limitation for PostgreSQL](../createBackups/EnablePITR.md#limitation) section for a workaround.
+    For PostgreSQL, point-in-time recovery (PITR) can get stuck in a **Restoring** state when you attempt to recover the database after the last transaction. See the [Limitation for PostgreSQL](createBackups/EnablePITR.md#limitations) section for a workaround.
 
 
 To restore to a point-in-time recovery:


### PR DESCRIPTION
## Summary

Fix the broken PostgreSQL PITR limitation link on the Restore Backup page.

- Correct the relative path to `EnablePITR.md`.
- Update the anchor from `#limitation` to the existing `#limitations` section.
- Keep users within the backup and restore documentation flow.

## Verification

- Ran `mkdocs build -f mkdocs.yml`.
- Confirmed no warnings remain for `backups_and_restore/RestoreBackup.md`.
- Verified the link opens the PITR limitations section.
- Ran `git diff --check`.