### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.x'
 

--- a/.github/workflows/good-first-issue.yml
+++ b/.github/workflows/good-first-issue.yml
@@ -11,7 +11,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           # The URL of your specific project
           project-url: https://github.com/orgs/openeverest/projects/2


### PR DESCRIPTION
## Why

Actions must now be pinned to full-length commit SHAs at the org level. A mutable tag means the action's owner — or anyone who compromises them — can change what executes in our pipelines retroactively, and unpinned workflows no longer run.

## What

Every `uses:` tag reference is replaced with the commit SHA that tag points at today, keeping the human-readable version in a trailing comment:

```diff
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
```

- **Behaviour-preserving** — same code runs, it just can't change underneath us.
- Annotated tags were dereferenced to the underlying commit.
- Comments use the most specific release tag pointing at that commit (`v4.4.0` rather than `v4`), matching the convention already used in `openeverest/main`.
- Line-for-line; no reordering or reformatting.

Generated mechanically and YAML-validated. Part of an org-wide sweep across all repositories.
