### PR TITLE
ci: declare explicit token permissions for workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/good-first-issue.yml
+++ b/.github/workflows/good-first-issue.yml
@@ -6,6 +6,9 @@ on:
       - labeled
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     name: Add issue to project


### PR DESCRIPTION
## Why

Neither workflow declares a `permissions:` block, so both inherit the org-level default for `GITHUB_TOKEN`. That default was recently changed to **read repository contents**, so nothing is broken today — but a workflow that doesn't state its needs silently tracks whatever the org setting happens to be, with no review signal when it changes.

## Changes

Both get `contents: read`:

- **`build.yml`** — builds the docs site; checkout and build only, no token writes.
- **`good-first-issue.yml`** — uses `actions/add-to-project` with `secrets.ADD_TO_PROJECT_PAT`, not `GITHUB_TOKEN`, so the default token only needs read.

## Note

`good-first-issue.yml` uses a secret named `ADD_TO_PROJECT_PAT`, while the same workflow in `openeverest`, `helm-charts`, `plugin-hub`, `openeverest.github.io` and `provider-altinity-clickhouse` uses `PROJECT_TOKEN` for the identical action and the identical org project (`orgs/openeverest/projects/2`).

Two secrets doing the same job means two credentials to rotate and two chances to miss one. Worth consolidating onto a single org-level secret — separate change, not bundled here.
