### PR TITLE
docs: document DataImporter S3 credential encoding requirements

### DIFF
--- a/docs/backups_and_restore/dataimporters/pg_dataimporter.md
+++ b/docs/backups_and_restore/dataimporters/pg_dataimporter.md
@@ -34,6 +34,9 @@ This section outlines the step-by-step process for importing backups using the O
         - **Region**: Select the geographical AWS region where your bucket is hosted (e.g., us-east-1, eu-west-1)
         - **Access key**: Enter your AWS Access Key ID (like a username for API access).
         - **Secret key**: Enter your AWS Secret Access Key (like a password for secure API access).
+
+        !!! info "Important"
+            Enter the **Access key** and **Secret key** in the same format: either both as plain text or both as base64-encoded values. OpenEverest rejects credentials that use mixed formats.
         
         Click **Save**.
 
@@ -125,7 +128,6 @@ This section outlines the step-by-step process for importing backups using the O
 
 
         
-
 
 
 

--- a/docs/backups_and_restore/dataimporters/psmdb_dataimporter.md
+++ b/docs/backups_and_restore/dataimporters/psmdb_dataimporter.md
@@ -35,6 +35,9 @@ This section outlines the step-by-step process for importing backups using the O
         - **Region**: Select the geographical AWS region where your bucket is hosted (e.g., us-east-1, eu-west-1)
         - **Access key**: Enter your AWS Access Key ID (like a username for API access).
         - **Secret key**: Enter your AWS Secret Access Key (like a password for secure API access).
+
+        !!! info "Important"
+            Enter the **Access key** and **Secret key** in the same format: either both as plain text or both as base64-encoded values. OpenEverest rejects credentials that use mixed formats.
             
         Click **Save**.
 
@@ -138,8 +141,6 @@ This section outlines the step-by-step process for importing backups using the O
 
 
         
-
-
 
 
 

--- a/docs/backups_and_restore/dataimporters/pxc_dataimporter.md
+++ b/docs/backups_and_restore/dataimporters/pxc_dataimporter.md
@@ -36,6 +36,9 @@ This section outlines the step-by-step process for importing backups using the O
         - **Region**: Select the geographical AWS region where your bucket is hosted (e.g., us-east-1, eu-west-1)
         - **Access key**: Enter your AWS Access Key ID (like a username for API access).
         - **Secret key**: Enter your AWS Secret Access Key (like a password for secure API access).
+
+        !!! info "Important"
+            Enter the **Access key** and **Secret key** in the same format: either both as plain text or both as base64-encoded values. OpenEverest rejects credentials that use mixed formats.
         
         Click **Save**.
 
@@ -142,7 +145,6 @@ This section outlines the step-by-step process for importing backups using the O
 
 
         
-
 
 
 


### PR DESCRIPTION
## Summary

Clarify the required encoding format for S3 credentials used by DataImporters. The S3 access key and secret key must both be provided as plain text or both as base64-encoded values. OpenEverest rejects credentials when these formats are mixed.

## Changes

- Add an **Important** information box next to the S3 credential fields.
  - Document the credential format requirement for:
    - PostgreSQL DataImporter
    - MySQL/PXC DataImporter
    - MongoDB/PSMDB DataImporter
  - Clarify that mixing plain-text and base64-encoded credentials causes validation to fail.

## Visual changes

### PostgreSQL

<img width="1436" height="665" alt="Screenshot 2026-08-03 at 8 54 21 AM" src="https://github.com/user-attachments/assets/71ba39fb-ee23-4392-b8f5-8e3d93adad5d" />


### MySQL/PXC

<img width="1440" height="663" alt="Screenshot 2026-08-03 at 8 54 31 AM" src="https://github.com/user-attachments/assets/c7f50ba5-651a-4662-a5e9-91c1c0d62470" />

### MongoDB/PSMDB

<img width="1435" height="663" alt="Screenshot 2026-08-03 at 8 54 42 AM" src="https://github.com/user-attachments/assets/a5575f37-aecf-40ce-983d-79044935cd03" />

## Verification
  - Ran the MkDocs build successfully.
  - Verified that the information box renders correctly on all three DataImporter pages.

## Related issue
 
Fixes openeverest/openeverest#1974

 ---

  Signed-off-by: nycanshu <hkg43700@gmail.com>